### PR TITLE
#168261432 text removed in header image

### DIFF
--- a/UI/html/users/request_mentorship.html
+++ b/UI/html/users/request_mentorship.html
@@ -10,13 +10,15 @@
 </head>
 <body>
   <header>
-    <span>Free Mentors</span>
+    <img src="../../img/cover.jpg" alt="png">
   </header>
+    <div class="logo-img">
+      <img src="../../img/free_mentors_logo.png" alt="">
+    </div>
   <nav>
     <div class="container">
       <div class="nav-left">
         <ul>
-          <li><span>Free Mentors<span></li>
           <li><a href="../../index.html">Home</a></li>
           <li><a href="view_mentors.html" class="active">View Mentors</a></li>
           <li><a href="apply_mentor.html">Become a Mentor</a></li>

--- a/UI/html/users/signin.html
+++ b/UI/html/users/signin.html
@@ -10,13 +10,15 @@
 </head>
 <body>
   <header>
-    <span>Free Mentors</span>
+    <img src="../../img/cover.jpg" alt="png">
   </header>
+    <div class="logo-img">
+      <img src="../../img/free_mentors_logo.png" alt="">
+    </div>
   <nav>
     <div class="container">
       <div class="nav-left">
         <ul>
-          <li><span>Free Mentors<span></li>
           <li><a href="../../index.html">Home</a></li>
           <li><a href="view_mentors.html">View Mentors</a></li>
           <li><a href="apply_mentor.html">Become a Mentor</a></li>

--- a/UI/html/users/view_mentors.html
+++ b/UI/html/users/view_mentors.html
@@ -10,13 +10,15 @@
 </head>
 <body>
   <header>
-    <span>Free Mentors</span>
+    <img src="../../img/cover.jpg" alt="png">
   </header>
+    <div class="logo-img">
+      <img src="../../img/free_mentors_logo.png" alt="">
+    </div>
   <nav>
     <div class="container">
       <div class="nav-left">
         <ul>
-          <li><span>Free Mentors<span></li>
           <li><a href="../../index.html">Home</a></li>
           <li><a href="view_mentors.html" class="active">View Mentors</a></li>
           <li><a href="apply_mentor.html">Become a Mentor</a></li>
@@ -43,63 +45,63 @@
             <th></th>
           </tr>
           <tr>
-            <td>John</td>
-            <td>Doe</td>
+            <td>Eddy</td>
+            <td>Kenthia</td>
+            <td>England</td>
+            <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
+          </tr>
+          <tr>
+            <td>Clint</td>
+            <td>Dempsay</td>
+            <td>USA</td>
+            <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
+          </tr>
+          <tr>
+            <td>Sinshuke</td>
+            <td>Nakamura</td>
+            <td>Japan</td>
+            <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
+          </tr>
+          <tr>
+            <td>Seth</td>
+            <td>Rollins</td>
+            <td>USA</td>
+            <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
+          </tr>
+          <tr>
+            <td>Daniel</td>
+            <td>James</td>
+            <td>Wales</td>
+            <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
+          </tr>
+          <tr>
+            <td>Antoine</td>
+            <td>Maurice</td>
+            <td>France</td>
+            <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
+          </tr>
+          <tr>
+            <td>Adama</td>
+            <td>Traore</td>
+            <td>Mali</td>
+            <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
+          </tr>
+          <tr>
+            <td>Iche</td>
+            <td>Chuchueza</td>
             <td>Nigeria</td>
             <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
           </tr>
           <tr>
-            <td>John</td>
-            <td>Doe</td>
-            <td>Nigeria</td>
+            <td>David</td>
+            <td>Jonhstone</td>
+            <td>USA</td>
             <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
           </tr>
           <tr>
-            <td>John</td>
-            <td>Doe</td>
-            <td>Nigeria</td>
-            <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
-          </tr>
-          <tr>
-            <td>John</td>
-            <td>Doe</td>
-            <td>Nigeria</td>
-            <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
-          </tr>
-          <tr>
-            <td>John</td>
-            <td>Doe</td>
-            <td>Nigeria</td>
-            <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
-          </tr>
-          <tr>
-            <td>John</td>
-            <td>Doe</td>
-            <td>Nigeria</td>
-            <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
-          </tr>
-          <tr>
-            <td>John</td>
-            <td>Doe</td>
-            <td>Nigeria</td>
-            <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
-          </tr>
-          <tr>
-            <td>John</td>
-            <td>Doe</td>
-            <td>Nigeria</td>
-            <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
-          </tr>
-          <tr>
-            <td>John</td>
-            <td>Doe</td>
-            <td>Nigeria</td>
-            <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
-          </tr>
-          <tr>
-            <td>John</td>
-            <td>Doe</td>
-            <td>Nigeria</td>
+            <td>Victor</td>
+            <td>Lindelof</td>
+            <td>Sweeden</td>
             <td id="link"><a href="mentor_profile.html" class="link" title="View Mentor">View</a></td>
           </tr>
         </table>


### PR DESCRIPTION
#### What does this PR do?

- Has removed text in header image

#### How should this be manually tested?

- when user access free mentors web application then should not view a text in image header

#### What are the relevant pivotal tracker stories?

- #168261432

#### Screenshots 
![no-text](https://user-images.githubusercontent.com/38500196/64175706-2552b080-ce5c-11e9-88d6-ca212e2ad91a.png)
